### PR TITLE
Listen on all interfaces

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM openjdk:11.0.4-jre-slim@sha256:c967fe34180ad9182a7bb52d7b57a807a2a5e07242b4
 RUN mkdir /app
 ADD ./build/distributions/test-app-1.0-SNAPSHOT.tgz /app
 WORKDIR /app/test-app-1.0-SNAPSHOT
-CMD ["./bin/test-app", "localhost", "12345"]
+CMD ["./bin/test-app", "0.0.0.0", "12345"]


### PR DESCRIPTION
When listening on `localhost`, the app won't be able to receive connections from outside of the container. Changing it to `0.0.0.0` to allow all connections.